### PR TITLE
Expose writeMaskedPayload

### DIFF
--- a/src/base/client.zig
+++ b/src/base/client.zig
@@ -438,10 +438,7 @@ test "attempt echo on echo.websocket.org" {
         .length = 4,
     });
 
-    var masked: [4]u8 = undefined;
-    client.maskPayload("test", &masked);
-
-    try client.writeUnmaskedPayload(&masked);
+    try client.writeMessagePayload("test");
 
     var header = (try client.readEvent()).?;
     testing.expect(header == .header);

--- a/src/base/client.zig
+++ b/src/base/client.zig
@@ -224,6 +224,15 @@ pub fn Client(comptime Reader: type, comptime Writer: type) type {
             try self.writer.writeAll(payload);
         }
 
+        pub fn writeMaskedPayload(self: *Self, payload: []const u8) WriterError!void {
+            const mask = self.current_mask.?;
+            for (payload) |c, i| {
+                try self.writer.writeByte(c ^ extractMaskByte(mask, i + self.mask_index));
+            }
+
+            self.mask_index += payload.len;
+        }
+
         pub fn readEvent(self: *Self) ReaderError!?ClientEvent {
             switch (self.state) {
                 .header => {

--- a/src/base/client.zig
+++ b/src/base/client.zig
@@ -220,11 +220,11 @@ pub fn Client(comptime Reader: type, comptime Writer: type) type {
             }
         }
 
-        pub fn writeMessagePayload(self: *Self, payload: []const u8) WriterError!void {
+        pub fn writeUnmaskedPayload(self: *Self, payload: []const u8) WriterError!void {
             try self.writer.writeAll(payload);
         }
 
-        pub fn writeMaskedPayload(self: *Self, payload: []const u8) WriterError!void {
+        pub fn writeMessagePayload(self: *Self, payload: []const u8) WriterError!void {
             const mask = self.current_mask.?;
             for (payload) |c, i| {
                 try self.writer.writeByte(c ^ extractMaskByte(mask, i + self.mask_index));
@@ -362,7 +362,7 @@ test "decodes a simple message" {
         .length = 9,
     });
 
-    try client.writeMessagePayload("aaabbbccc");
+    try client.writeUnmaskedPayload("aaabbbccc");
 
     var header = (try client.readEvent()).?;
     testing.expect(header == .header);
@@ -399,7 +399,7 @@ test "decodes a masked message" {
         .length = 9,
     });
 
-    try client.writeMessagePayload("aaabbbccc");
+    try client.writeUnmaskedPayload("aaabbbccc");
 
     var header = (try client.readEvent()).?;
     testing.expect(header == .header);
@@ -441,7 +441,7 @@ test "attempt echo on echo.websocket.org" {
     var masked: [4]u8 = undefined;
     client.maskPayload("test", &masked);
 
-    try client.writeMessagePayload(&masked);
+    try client.writeUnmaskedPayload(&masked);
 
     var header = (try client.readEvent()).?;
     testing.expect(header == .header);


### PR DESCRIPTION
Not sure if this is architecturally sound, but this enables the callsite to remove an extra copy buffer by shoving the masked data directly into the writer.