### PR TITLE
client.zig: Correct handshake key length

### DIFF
--- a/src/base/client.zig
+++ b/src/base/client.zig
@@ -28,7 +28,7 @@ pub fn create(buffer: []u8, reader: anytype, writer: anytype) Client(@TypeOf(rea
 }
 
 const websocket_guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-const handshake_key_length = 8;
+const handshake_key_length = 16;
 
 fn checkHandshakeKey(original: []const u8, recieved: []const u8) bool {
     var hash = Sha1.init(.{});


### PR DESCRIPTION
The WebSocket spec states that:

>  7.   The request MUST include a header field with the name
        |Sec-WebSocket-Key|.  The value of this header field MUST be a
        nonce consisting of a randomly selected **16-byte value** that has
        been base64-encoded (see Section 4 of [RFC4648]).  The nonce
        MUST be selected randomly for each connection.