### PR TITLE
Fix write header for small payload lengths

### DIFF
--- a/src/base/client.zig
+++ b/src/base/client.zig
@@ -204,7 +204,7 @@ pub fn BaseClient(comptime Reader: type, comptime Writer: type) type {
                 self.prng.bytes(&mask);
             }
 
-            bytes[1] |= 0x80;
+            bytes[1] = 0x80;
 
             if (header.length < 126) {
                 bytes[1] |= @truncate(u8, header.length);


### PR DESCRIPTION
The broken code sets `byte[1] = undefined | 0x80`.

In a prior version, this byte was [initialized as `byte[1] = 0;`](https://github.com/truemedian/wz/blob/7b32eea28fc8e3af5f2784df84e55547ebaa7892/src/base/client.zig#L149) but the current iteration doesn't set this. I think assigning directly to 0x80 makes more sense.